### PR TITLE
correction of institute error

### DIFF
--- a/beamerthemevertex.sty
+++ b/beamerthemevertex.sty
@@ -191,7 +191,7 @@
   \begin{beamercolorbox}[wd=1\paperwidth, ht=2.5ex, dp=1ex]{footline}
     \begin{beamercolorbox}[wd=0.2\paperwidth, ht=2.5ex, dp=1ex, left, leftskip=1em]{author in head/foot}%
     \strut\insertshortauthor%
-    \ifx\insershortinstitute\@empty\else%
+    \ifx\insertinstitute\@empty\else%
     ~–~\insertshortinstitute%
     \fi%
     \end{beamercolorbox}%


### PR DESCRIPTION
There is always a dash behind the author's name per default because of a a missing `t` in line 194 in `\insertshortinstitute`. 
But that is not the only error. It's still there if you correct that. The variable `\insertshortinstitute` seems to be not empty per default. You can fix that by using `\insertinstitute` instead.