### PR TITLE
fix error for simplefootline option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 
 # Vertex - A theme for LaTeX-Beamer
 
+## Theme Options
+
+- `\usetheme[simplefootline]{vertex}` - use a simpler footline
+- `\usetheme[totalframes]{vertex}` - show total number of slides
+
 ## Title page
 ![title page](./demo.png)
 

--- a/beamerthemevertex.sty
+++ b/beamerthemevertex.sty
@@ -186,12 +186,15 @@
 \leavevmode%
 \if@simplefootline%
   \hfill
+  \begin{beamercolorbox}[wd=0.2\paperwidth, ht=2.5ex, dp=1ex, right, rightskip=1em]{page number in head/foot}%
+    \strut\insertframenumber{}\if@totalframes /\inserttotalframenumber{}\fi%
+  \end{beamercolorbox}%
 \else%
   \usebeamerfont{footline}%
   \begin{beamercolorbox}[wd=1\paperwidth, ht=2.5ex, dp=1ex]{footline}
     \begin{beamercolorbox}[wd=0.2\paperwidth, ht=2.5ex, dp=1ex, left, leftskip=1em]{author in head/foot}%
-    \strut\insertshortauthor%
-    \ifx\beamer@shortinstitute\@empty\else~–~\insertshortinstitute\fi%
+      \strut\insertshortauthor%
+      \ifx\beamer@shortinstitute\@empty\else~–~\insertshortinstitute\fi%
     \end{beamercolorbox}%
     \begin{beamercolorbox}[wd=0.6\paperwidth, ht=2.5ex, dp=1ex, center]{section in head/foot}%
       \strut\insertshorttitle%
@@ -204,11 +207,11 @@
         {~–~}\insertsubsectionhead%
       \fi%
     \end{beamercolorbox}%
-  \fi%
-  \begin{beamercolorbox}[wd=0.2\paperwidth, ht=2.5ex, dp=1ex, right, rightskip=1em]{page number in head/foot}%
-    \strut\insertframenumber{}\if@totalframes / \inserttotalframenumber{}\fi%
+    \begin{beamercolorbox}[wd=0.2\paperwidth, ht=2.5ex, dp=1ex, right, rightskip=1em]{page number in head/foot}%
+      \strut\insertframenumber{}\if@totalframes / \inserttotalframenumber{}\fi%
+    \end{beamercolorbox}%
   \end{beamercolorbox}%
-\end{beamercolorbox}%
+\fi%
 }
 
 % Blocks


### PR DESCRIPTION
The .sty provides the nice 'simplefootline' option, which was not working.
This due to wrong nesting of `\if` and `\begin{beamercolorbox}`. I took the chance to add a small description of the options in the README.